### PR TITLE
Thread-safety

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,24 @@ project(lr VERSION 1.0
 add_library(lr STATIC src/lr.c)
 target_include_directories(lr PUBLIC include)
 
+enable_testing()
+
 add_executable(test_basic test/basic.c)
 target_link_libraries(test_basic lr)
 
-add_test(NAME basic_test
-    COMMAND basic_test)
+add_test(NAME test_basic
+    COMMAND test_basic)
 
 add_executable(test_edge test/edge.c)
 target_link_libraries(test_edge lr)
 
-add_test(NAME edge_test
-    COMMAND edge_test)
+add_test(NAME test_edge
+    COMMAND test_edge)
+
+
+add_executable(test_multi_thread test/multi_thread.c)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+target_link_libraries(test_multi_thread PRIVATE lr Threads::Threads)
+add_test(NAME test_multi_thread
+    COMMAND test_multi_thread)

--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ Therefore, memory consumption of Linked Ring Buffer in multiple producer case is
 
 As we can see, Linked Ring Buffer uses less memory in multiple consumer case.
 
+#### Thread-safety
+- The Linked Ring Buffer Library, by default, is not thread-safe. However, the user can override this behavior by passing in custom lock and unlock functions, which the library will call to ensure that all operations, except for `lr_dump`, are thread-safe. `lr_dump` is a debugging function so it is assumed that the caller is taking extra measures to protect against race conditions. 
+
 ## License
 
 The Linked Ring Buffer Library is licensed under the MIT License, as described in the LICENSE.md file. This license allows users to use, modify, and distribute the code as they see fit, with minimal restrictions. Please be sure to read and understand the terms of the license before using the code
@@ -162,7 +165,6 @@ The Linked Ring Buffer Library is licensed under the MIT License, as described i
 The Linked Ring Buffer Library is an open source project, and we welcome contributions from the community! There are several areas where you can make a meaningful contribution to the library:
 
 -   **[Add Option to Overflow Filled Buffer](https://github.com/fefa4ka/linked_ring/issues/1)**: Currently, the buffer is fixed-size and cannot hold more elements than its size. You can help by adding the option to allow the buffer to overflow when it is filled, discarding the oldest data in favor of the new data. This could be useful in certain scenarios where it is necessary to store more data in the buffer than it can hold. You could modify the `lr_put()` function to check if the buffer is full before adding a new element, and provide a flag or configuration option to allow users to specify whether they want to enable overflow behavior or not.
--   **[Make It Safe for Threads](https://github.com/fefa4ka/linked_ring/issues/2)**: The Linked Ring Buffer Library is currently not thread-safe, which means that it cannot be used in multithreaded environments without additional measures to protect against race conditions. You can help by adding support for thread-safety to the library, using techniques such as mutexes or atomic operations.
 -   **Convenient Definition of an Arbitrary Data Type for Elements**: Currently, the `lr_data_t` field is defined as a `void * type`, which allows for the storage of any type of data. However, this can be inconvenient for users who want to store specific types of data in the buffer. You can help by providing a more convenient way for users to define the data type for elements in the buffer.
 -   **Use Hash Tables** for `O(log n)` Buffer Reads: Currently, the `lr_exists()` function has `O(n)` time complexity, meaning that it takes longer to execute as the number of elements in the buffer increases. You can help by implementing a hash table-based solution that allows for `O(log n)` time complexity for this function.
 -   **Measure and Compare Performance**: The Linked Ring Buffer Library is designed to be efficient and performant, but it is always important to verify and validate these claims. You can help by implementing performance tests and benchmarks to measure and compare the performance of the Linked Ring Buffer Library with other data structures.

--- a/src/lr.c
+++ b/src/lr.c
@@ -1,17 +1,35 @@
 #include "lr.h"
 #include <stdio.h>
 
-#define RETURN_IF_ERROR(x) do { \
-  enum lr_result ret = (x); \
-  if (ret != LR_OK) { \
-    return ret; \
-  } \
+
+/* lock the mutex if lock function provided, no op otherwise */
+#define maybe_lock(lr, owner) do { \
+  if (lr->lock != NULL) { \
+    enum lr_result ret = lr->lock(lr->mutex_state, owner); \
+    if (ret != LR_OK) { \
+        return ret; \
+    } \
+   } \
 } while (0)
+
+/* additional overload if owner is unknown */
+#define maybe_lock_no_owner(lr) maybe_lock(lr, 0)
+
+/* unlock the mutex if unlock function provided and then return ret  */
+#define maybe_unlock_and_return(lr, ret) do { \
+  if (lr->unlock != NULL) { \
+    return lr->unlock(lr->mutex_state); \
+   } \
+   return ret; \
+} while (0)
+
+/* additional overload for returning success */
+#define maybe_unlock_and_succeed(lr) maybe_unlock_and_return(lr, LR_OK)
 
 uint16_t lr_count_limited_owned(struct linked_ring *lr, uint16_t limit,
                                 lr_owner_t owner)
 {
-    RETURN_IF_ERROR(lr->mutex.lock());
+    maybe_lock(lr, owner);
     uint8_t         length  = 0;
     struct lr_cell *counter = lr->read;
     struct lr_cell *needle  = lr->write ? lr->write : lr->read;
@@ -19,20 +37,19 @@ uint16_t lr_count_limited_owned(struct linked_ring *lr, uint16_t limit,
     /* Return 0 if the buffer is empty */
     if (lr->read == 0)
     {
-        return lr->mutex.unlock();
+        maybe_unlock_and_succeed(lr);
     }
 
     /* Return 0 if the owner is not present in the buffer */
     if (owner && (lr->owners & owner) != owner)
     {
-        return lr->mutex.unlock();
+        maybe_unlock_and_succeed(lr);
     }
 
     /* Full buffer */
     if (!owner && lr->write == 0)
     {
-        RETURN_IF_ERROR(lr->mutex.unlock());
-        return lr->size;
+        maybe_unlock_and_return(lr, lr->size);
     }
 
     /* Iterate through the buffer and count the elements owned by the specified
@@ -46,8 +63,7 @@ uint16_t lr_count_limited_owned(struct linked_ring *lr, uint16_t limit,
             break;
     } while (counter != needle || (limit && limit == length));
 
-    RETURN_IF_ERROR(lr->mutex.unlock());
-    return length;
+    maybe_unlock_and_return(lr, length);
 }
 
 /* This function initializes a new linked ring buffer.
@@ -60,7 +76,7 @@ uint16_t lr_count_limited_owned(struct linked_ring *lr, uint16_t limit,
  *     LR_ERROR_NOMEMORY: if the cells parameter is NULL or size is 0
  */
 lr_result_t lr_init(struct linked_ring *lr, unsigned int size,
-                    struct lr_cell *cells, struct lr_recursive_mutex mutex)
+                    struct lr_cell *cells)
 {
     lr->cells = cells;
     if (lr->cells == 0 || size <= 0) {
@@ -74,20 +90,34 @@ lr_result_t lr_init(struct linked_ring *lr, unsigned int size,
     // Set the write position to the first cell in the buffer
     lr->write = lr->cells;
 
-    lr->mutex.lock = mutex.lock;
-    lr->mutex.unlock = mutex.unlock;
+    // use lr_set_mutex to initialize these fields
+    lr->lock = NULL;
+    lr->unlock = NULL;
+    lr->mutex_state = NULL;
 
+    return LR_OK;
+}
+
+/* This function sets the mutex for a linked ring buffer.
+ * Parameters:
+ *     lr: pointer to the linked ring structure to be initialized
+ *     attr: mutex attributes
+ */
+void lr_set_mutex(struct linked_ring *lr, struct lr_mutex_attr *attr)
+{
+    lr->lock = attr->lock;
+    lr->unlock = attr->unlock;
+    lr->mutex_state = attr->state;
     return LR_OK;
 }
 
 lr_result_t lr_put(struct linked_ring *lr, lr_data_t data, lr_owner_t owner)
 {
-    RETURN_IF_ERROR(lr->mutex.lock());   
+    maybe_lock(lr, owner);
     /* Check if the buffer is full */
     if (!lr->write && lr->read)
     {
-        RETURN_IF_ERROR(lr->mutex.unlock());
-        return LR_ERROR_BUFFER_FULL;
+        maybe_unlock_and_return(lr, LR_ERROR_BUFFER_FULL);
     }
         
 
@@ -121,8 +151,7 @@ lr_result_t lr_put(struct linked_ring *lr, lr_data_t data, lr_owner_t owner)
     if (!lr->read)
         lr->read = cell;
 
-    RETURN_IF_ERROR(lr->mutex.unlock());
-    return LR_OK;
+    maybe_unlock_and_succeed(lr);
 }
 
 lr_result_t lr_put_string(struct linked_ring *lr, unsigned char *data,
@@ -138,7 +167,7 @@ lr_result_t lr_put_string(struct linked_ring *lr, unsigned char *data,
 
 lr_result_t lr_get(struct linked_ring *lr, lr_data_t *data, lr_owner_t owner)
 {
-    RETURN_IF_ERROR(lr->mutex.lock());
+    maybe_lock(lr, owner);
     struct lr_cell *readable_cell = lr->read;
     struct lr_cell *previous_cell = 0;
     struct lr_cell *freed_cell    = 0;
@@ -146,8 +175,7 @@ lr_result_t lr_get(struct linked_ring *lr, lr_data_t *data, lr_owner_t owner)
 
     if (lr_count_owned(lr, owner) == 0)
     {
-        RETURN_IF_ERROR(lr->mutex.unlock());
-        return LR_ERROR_BUFFER_EMPTY;
+        maybe_unlock_and_return(lr, LR_ERROR_BUFFER_EMPTY);
     }
     
     /* Flush owners, and set again during buffer reading */
@@ -168,9 +196,7 @@ lr_result_t lr_get(struct linked_ring *lr, lr_data_t *data, lr_owner_t owner)
                 if (readable_cell->next == needle) {
                     readable_cell->next = lr->write ? lr->write : lr->read;
                     lr->write           = readable_cell;
-
-                    RETURN_IF_ERROR(lr->mutex.unlock());
-                    return LR_OK;
+                    maybe_unlock_and_succeed(lr);
                 } else {
                     previous_cell->next = readable_cell->next;
                 }
@@ -180,8 +206,7 @@ lr_result_t lr_get(struct linked_ring *lr, lr_data_t *data, lr_owner_t owner)
                     lr->read  = 0;
                     readable_cell->next = lr->write ? lr->write : lr->read;
                     lr->write = readable_cell;
-                    RETURN_IF_ERROR(lr->mutex.unlock());
-                    return LR_OK;
+                    maybe_unlock_and_succeed(lr);
                 } else {
                     /* Once case when read pointer changing
                      * If readed first cell */
@@ -207,8 +232,7 @@ lr_result_t lr_get(struct linked_ring *lr, lr_data_t *data, lr_owner_t owner)
     } while (readable_cell != needle && readable_cell);
 
     if (owner != 0xFFFF) {
-        RETURN_IF_ERROR(lr->mutex.unlock());
-        return LR_ERROR_BUFFER_EMPTY;
+        maybe_unlock_and_return(lr, LR_ERROR_BUFFER_EMPTY);
     } else {
         /* Last iteration. Link freed cell as next */
         previous_cell->next = freed_cell;
@@ -217,18 +241,16 @@ lr_result_t lr_get(struct linked_ring *lr, lr_data_t *data, lr_owner_t owner)
         lr->write = freed_cell;
     }
 
-    RETURN_IF_ERROR(lr->mutex.unlock());
-    return LR_OK;
+    maybe_unlock_and_succeed(lr);
 }
 
 lr_result_t lr_dump(struct linked_ring *lr)
 {
-    RETURN_IF_ERROR(lr->mutex.lock());
+    maybe_lock_no_owner(lr);
     struct lr_cell *needle = lr->write ? lr->write : lr->read;
     if (lr_count(lr) == 0)
     {
-        lr->mutex.unlock();
-        return LR_ERROR_BUFFER_EMPTY;
+        maybe_unlock_and_return(lr, LR_ERROR_BUFFER_EMPTY);
     }
        
     printf("\nLinked ring buffer dump\n");
@@ -253,6 +275,5 @@ lr_result_t lr_dump(struct linked_ring *lr)
 
     printf("%x\n", lr->write);
 
-    RETURN_IF_ERROR(lr->mutex.unlock());
-    return LR_OK;
+    maybe_unlock_and_succeed(lr);
 }

--- a/test/basic.c
+++ b/test/basic.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+
 #define log_print(type, message, ...)                                          \
     printf(type "\t" message "\n", ##__VA_ARGS__)
 #define log_debug(type, message, ...)                                          \
@@ -25,19 +26,31 @@
 struct linked_ring buffer; // declare a buffer for the Linked Ring
 
 
+// used to mock lock and unlock for single-threaded tests
+enum lr_result always_return_ok() 
+{
+    return LR_OK;
+}
+
 int main()
 {
+
+    struct lr_recursive_mutex mutex;
+    mutex.lock = always_return_ok;
+    mutex.unlock = always_return_ok;
+
+    
     // allocate memory for the cells in the Linked Ring buffer
     lr_result_t     result;
     unsigned int    size  = 10;
     struct lr_cell *cells = malloc(size * sizeof(struct lr_cell));
 
     // Test lr_init() with size 0
-    result = lr_init(&buffer, 0, cells);
+    result = lr_init(&buffer, 0, cells, mutex);
     test_assert(result == LR_ERROR_NOMEMORY, "Buffer could not be 0 size");
 
     // Test lr_init() with size
-    result = lr_init(&buffer, size, cells);
+    result = lr_init(&buffer, size, cells, mutex);
     test_assert(result == LR_OK, "Buffer with size %d should be initialized",
                 size);
 

--- a/test/basic.c
+++ b/test/basic.c
@@ -25,32 +25,19 @@
 
 struct linked_ring buffer; // declare a buffer for the Linked Ring
 
-
-// used to mock lock and unlock for single-threaded tests
-enum lr_result always_return_ok() 
-{
-    return LR_OK;
-}
-
 int main()
-{
-
-    struct lr_recursive_mutex mutex;
-    mutex.lock = always_return_ok;
-    mutex.unlock = always_return_ok;
-
-    
+{    
     // allocate memory for the cells in the Linked Ring buffer
     lr_result_t     result;
     unsigned int    size  = 10;
     struct lr_cell *cells = malloc(size * sizeof(struct lr_cell));
 
     // Test lr_init() with size 0
-    result = lr_init(&buffer, 0, cells, mutex);
+    result = lr_init(&buffer, 0, cells);
     test_assert(result == LR_ERROR_NOMEMORY, "Buffer could not be 0 size");
 
     // Test lr_init() with size
-    result = lr_init(&buffer, size, cells, mutex);
+    result = lr_init(&buffer, size, cells);
     test_assert(result == LR_OK, "Buffer with size %d should be initialized",
                 size);
 

--- a/test/edge.c
+++ b/test/edge.c
@@ -37,25 +37,14 @@ typedef enum {
     NUM_OWNERS
 } owner_t;
 
-// used to mock lock and unlock for single-threaded tests
-enum lr_result always_return_ok() 
-{
-    return LR_OK;
-}
-
-
 // function to initialize the linked ring buffer
 lr_result_t init_buffer(int buffer_size)
 {
     // create an array of lr_cell for the buffer
     struct lr_cell *cells = calloc(buffer_size, sizeof(struct lr_cell));
 
-    struct lr_recursive_mutex mutex;
-    mutex.lock = always_return_ok;
-    mutex.unlock = always_return_ok;
-
     // initialize the buffer
-    lr_result_t result = lr_init(&buffer, buffer_size, cells, mutex);
+    lr_result_t result = lr_init(&buffer, buffer_size, cells);
     if (result != LR_OK) {
         log_error("Failed to initialize buffer");
         return LR_ERROR_UNKNOWN;

--- a/test/edge.c
+++ b/test/edge.c
@@ -37,14 +37,25 @@ typedef enum {
     NUM_OWNERS
 } owner_t;
 
+// used to mock lock and unlock for single-threaded tests
+enum lr_result always_return_ok() 
+{
+    return LR_OK;
+}
+
+
 // function to initialize the linked ring buffer
 lr_result_t init_buffer(int buffer_size)
 {
     // create an array of lr_cell for the buffer
     struct lr_cell *cells = calloc(buffer_size, sizeof(struct lr_cell));
 
+    struct lr_recursive_mutex mutex;
+    mutex.lock = always_return_ok;
+    mutex.unlock = always_return_ok;
+
     // initialize the buffer
-    lr_result_t result = lr_init(&buffer, buffer_size, cells);
+    lr_result_t result = lr_init(&buffer, buffer_size, cells, mutex);
     if (result != LR_OK) {
         log_error("Failed to initialize buffer");
         return LR_ERROR_UNKNOWN;
@@ -52,6 +63,8 @@ lr_result_t init_buffer(int buffer_size)
 
     return LR_OK;
 }
+
+
 
 lr_result_t add_random_data()
 {

--- a/test/multi_thread.c
+++ b/test/multi_thread.c
@@ -1,0 +1,140 @@
+#include <lr.h> // include header for Linked Ring library
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+#define log_print(type, message, ...)                                          \
+    printf(type "\t" message "\n", ##__VA_ARGS__)
+#define log_debug(type, message, ...)                                          \
+    log_print(type, message " (%s:%d)\n", ##__VA_ARGS__, __FILE__, __LINE__)
+#define log_verbose(message, ...) log_print("VERBOSE", message, ##__VA_ARGS__)
+#define log_info(message, ...)    log_print("INFO", message, ##__VA_ARGS__)
+#define log_ok(message, ...)      log_print("OK", message, ##__VA_ARGS__)
+#define log_error(message, ...)                                                \
+    log_print("\e[1m\e[31mERROR\e[39m\e[0m", message " (%s:%d)\n",             \
+              ##__VA_ARGS__, __FILE__, __LINE__)
+
+#define test_assert(test, message, ...)                                        \
+    if (!(test)) {                                                             \
+        log_error(message, ##__VA_ARGS__);                                     \
+        return LR_ERROR_UNKNOWN;                                               \
+    } else {                                                                   \
+        log_ok(message, ##__VA_ARGS__);                                        \
+    }
+
+struct linked_ring buffer; // declare a buffer for the Linked Ring
+pthread_mutex_t mutex;
+
+enum lr_result lock() 
+{
+    if (pthread_mutex_lock(&mutex) == 0)
+    {
+        return LR_OK; 
+    }
+    return LR_ERROR_UNKNOWN;
+}
+
+lr_result_t unlock()
+{
+    if (pthread_mutex_unlock(&mutex) == 0)
+    {
+        return LR_OK;
+    }
+    return LR_ERROR_UNKNOWN;
+}
+
+// function to initialize the linked ring buffer
+lr_result_t init_buffer(int buffer_size)
+{
+    // create an array of lr_cell for the buffer
+    struct lr_cell *cells = calloc(buffer_size, sizeof(struct lr_cell));
+
+    struct lr_recursive_mutex mutex;
+    mutex.lock = lock;
+    mutex.unlock = unlock;
+
+
+    // initialize the buffer
+    lr_result_t result = lr_init(&buffer, buffer_size, cells, mutex);
+    if (result != LR_OK) {
+        log_error("Failed to initialize buffer");
+        return LR_ERROR_UNKNOWN;
+    }
+
+    return LR_OK;
+}
+
+void *put_get_data(void *data_in)
+{
+    unsigned int owner = *((unsigned int *) data_in);
+    lr_data_t data = (lr_data_t) data_in;
+    enum lr_result result;
+    do 
+    {
+        result = lr_put(&buffer, (lr_data_t) data, owner);
+    } while(result != LR_ERROR_BUFFER_FULL && result != LR_OK);
+    lr_data_t read;
+    result = lr_get(&buffer, &read, owner);
+    if (result != LR_OK)
+    {
+        log_error("Error while getting data from buffer");
+        pthread_exit((void *) result);
+    }
+    if (read != data)
+    {
+        log_error("Data does not match");
+        result = LR_ERROR_UNKNOWN;
+        pthread_exit((void *) result);
+    }
+    else
+    {
+        pthread_exit((void *) result);
+    }
+}
+
+/** Invokes `num_threads` threads that each run `func`
+ *  Returns LR_OK on success.
+ *  If at least one of the threads reported an error, then this function returns the error of the thread that reported an error and that was joined last.
+ */
+lr_result_t test_multiple_threads(unsigned int num_threads, void *(*func)(void*))
+{
+    // use less cells than threads to force contention
+    unsigned int buffer_size = (num_threads > 1) ? num_threads / 2 : 1;
+    test_assert(init_buffer(buffer_size) == LR_OK, "Failed to initialize buffer");
+    pthread_t threads[num_threads];
+    unsigned int owners[num_threads];
+    for (unsigned int i = 0; i < num_threads; i++)
+    {
+        owners[i] = i;
+        int ret = pthread_create(&threads[i], NULL, func, (void *) &i);
+        test_assert(ret == 0, "Failed to create thread");
+    }
+
+    enum lr_result result = LR_OK;
+    for (unsigned int i = 0; i < num_threads; i++)
+    {
+        void *ret;
+        pthread_join(threads[i], &ret);
+        enum lr_result ret_as_result = (enum lr_result) ret;
+        result = (ret_as_result == LR_OK) ?  result : ret_as_result;
+    }
+    return result;
+}
+
+int main(int argc, char **argv)
+{
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&mutex, &attr);
+    // run the test function
+    enum lr_result result = test_multiple_threads(2, put_get_data);
+    if (result == LR_OK) {
+        log_ok("All tests passed");
+    } else {
+        log_error("Test failed");
+    }
+    return 0;
+}


### PR DESCRIPTION
Addresses thread-safety, issue #2 

* caller can provide function pointers for lock and unlock
* Example scenario of how `lock` and `unlock` may be used: An application stores logs; each log's owner field is set to a value that identifies which component of the application produced the log. Threads are used to read and process logs for a specific owner. The number of threads would be less than the number of components in the application. Latency doesn't matter here.
* a basic multi-threaded test
* validated locally using ctest, `gcc-8`, Ubuntu 20.04